### PR TITLE
Resolves #6

### DIFF
--- a/Application/src/RazorPagesTestSample/Data/Message.cs
+++ b/Application/src/RazorPagesTestSample/Data/Message.cs
@@ -9,7 +9,7 @@ namespace RazorPagesTestSample.Data
 
         [Required]
         [DataType(DataType.Text)]
-        [StringLength(200, ErrorMessage = "There's a 200 character limit on messages. Please shorten your message.")]
+        [StringLength(250, ErrorMessage = "There's a 250 character limit on messages. Please shorten your message.")]
         public string Text { get; set; }
     }
     #endregion


### PR DESCRIPTION
This pull request to the Application project in the src/RazorPagesTestSample folder increases the character limit for the `Text` property in the `Message` class from 200 to 250 to accommodate longer messages.

* <a href="diffhunk://#diff-3a68b54c333d01e48727b3f767c1155f37920ee7e4b2bcc8fd5c0cda0debce19L12-R12">`Application/src/RazorPagesTestSample/Data/Message.cs`</a>: Increased character limit for `Text` property in `Message` class from 200 to 250.